### PR TITLE
Update makefile_linux

### DIFF
--- a/src/makefile_linux
+++ b/src/makefile_linux
@@ -14,7 +14,7 @@ LIBS :=  '-lpestpp_com -lrm_wrappers -lrm_yamr -lrm_serial -lrm_external -lrm_ge
 #CFLAGS := '-pthread -std=c++11 -Wl,--no-as-needed -g -gdwarf-2' 
 #FFLAGS := '-g -gdwarf-2 -c -cpp'
 
-CFLAGS := '-pthread  -Wl,--no-as-needed -O2' 
+CFLAGS := '-pthread  -Wl,--no-as-needed -O2 -std=c++11' 
 FFLAGS := '-O2 -c -cpp'
 LFLAGS := '-static -static-libgcc -static-libgfortran'
 


### PR DESCRIPTION
Hi Dave,
Need the -std=c++11 option.  At least on Cento 6.
Kindest regards,
Tim