### PR TITLE
Specify quadmath lib to had linker find it.

### DIFF
--- a/src/makefile_linux
+++ b/src/makefile_linux
@@ -9,7 +9,7 @@ RUN_MNG_DIR = $(CURDIR)/libs/run_managers
 EXE_DIR = ../exe/linux
 INCLUDES := '-I $(LIBS_DIR)/Eigen -I $(LIBS_DIR)/common -I $(LIBS_DIR)/run_managers/abstract_base -I $(RUN_MNG_DIR)/yamr -I $(RUN_MNG_DIR)/serial -I $(RUN_MNG_DIR)/genie_wrapper -I $(RUN_MNG_DIR)/external  -I $(RUN_MNG_DIR)/wrappers  -I $(LIBS_DIR)/pestpp_common -I $(LIBS_DIR)/linear_analysis'
 LIBLDIR := '-L $(GCCLIBDIR) -L /usr/lib64 -L/opt/local/lib64 -L /opt/hesm/lib64 -L $(LIBS_DIR)/common  -L$(RUN_MNG_DIR)/wrappers -L$(RUN_MNG_DIR)/serial -L$(RUN_MNG_DIR)/external -L$(RUN_MNG_DIR)/yamr -L$(RUN_MNG_DIR)/genie_wrapper -L$(RUN_MNG_DIR)/abstract_base -L $(LIBS_DIR)/pestpp_common -L $(LIBS_DIR)/mio -L $(LIBS_DIR)/propack -L $(LIBS_DIR)/linear_analysis'
-LIBS :=  '-lpestpp_com -lrm_wrappers -lrm_yamr -lrm_serial -lrm_external -lrm_genie_wrapper -lrm_abstract -lmio -lcommon -l propack -llapack -lblas -llinear_analysis -lgfortran $(GCCLIBDIR)/libquadmath.a'
+LIBS :=  '-lpestpp_com -lrm_wrappers -lrm_yamr -lrm_serial -lrm_external -lrm_genie_wrapper -lrm_abstract -lmio -lcommon -l propack -llapack -lblas -llinear_analysis -lgfortran -lquadmath'
 
 #CFLAGS := '-pthread -std=c++11 -Wl,--no-as-needed -g -gdwarf-2' 
 #FFLAGS := '-g -gdwarf-2 -c -cpp'


### PR DESCRIPTION
The path to the quadmath library was specified explicitly.  I think
having the linker find it is a more flexible solution.