### PR TITLE
Rewrite parts of Makefile setup to include STATIC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,22 @@
 *.a
 *.lib
 
+# Executables
+/src/programs/gsa/gsa
+/src/programs/pest++/pestpp
+/src/programs/pestpp-ies/pestpp-ies
+/src/programs/pestpp-opt/pestpp-opt
+/src/programs/pestpp-pso/psopp
+/src/utilities/ascii2pbin/ascii2pbin
+/src/utilities/pbin2ascii/pbin2ascii
+/src/utilities/pbin_dump/pbin_dump
+/src/utilities/sweep/sweep
+
 # User files
 /src/local.mak
+
+# Makefile object
+/src/libs/build-stamp
 
 /morris_meth/ipch
 /morris_meth/Debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,8 @@ sudo: false
 dist: trusty
 language: cpp
 
-os:
-  - linux
-#  - osx
-
-compiler:
-  - gcc
+#compiler:
+#  - gcc
 
 addons:
   apt:
@@ -27,7 +23,8 @@ env:
 
 script:
   - cd src
-  - CXX=g++-5 FC=gfortran-5 COMPILER=gcc make && make install
+  - COMPILER=gcc5 CXX=g++-5 FC=gfortran-5 STATIC=no make
+  - make install
 
 notifications:
   email: false

--- a/src/global.mak
+++ b/src/global.mak
@@ -6,19 +6,20 @@
 #        ?= win
 # COMPILER ?= gcc (default)
 #          ?= intel
+# STATIC ?= -static (default)
+#        ?= no (shared dynamic linking)
 # These can be kept in local.mak
 -include $(top_builddir)/local.mak
 
 # Autodetect SYSTEM
-#$(info $$OS is $(OS))
 ifeq ($(OS),Windows_NT)
 SYSTEM ?= win
 else
 UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S), Linux)
+ifeq ($(UNAME_S),Linux)
 SYSTEM ?= linux
 endif
-ifeq ($(UNAME_S), Darwin)
+ifeq ($(UNAME_S),Darwin)
 SYSTEM ?= mac
 endif
 endif
@@ -40,19 +41,25 @@ else
 $(error SYSTEM not understood: $(SYSTEM). Use one of mac, linux or win.)
 endif
 
+# Determine static (default '-static') or shared dynamic linking
+STATIC ?= -static
+ifndef STATIC
+STATIC = no
+endif
+
 ifeq ($(SYSTEM),win)
 # Microsoft Windows
-EXE_EXT	= .exe
-OBJ_EXT	= .obj
-LIB_EXT	= .lib
+EXE_EXT = .exe
+OBJ_EXT = .obj
+LIB_EXT = .lib
 CP = copy
 RM = del /Q
 MKDIR = md
 else
 # POSIX (mac, linux)
-OBJ_EXT	= .o
-LIB_PRE	= lib
-LIB_EXT	= .a
+OBJ_EXT = .o
+LIB_PRE = lib
+LIB_EXT = .a
 CP = cp
 MKDIR = mkdir -p
 endif
@@ -61,75 +68,105 @@ ifeq ($(COMPILER),intel)
 # Intel compilers
 ifeq ($(SYSTEM),win)
 # Warning: this build method is not well tested
-CXX	?= icl
-OPT_FLAGS	= /nologo /O2
-CXXFLAGS	= $(OPT_FLAGS) /Qstd=c++11 /EHsc
-FFLAGS	= $(OPT_FLAGS) /fpp
+CXX = icl
+OPT_FLAGS = /nologo /O2 /Qmkl:sequential
+CXXFLAGS = $(OPT_FLAGS) /Qstd=c++11 /EHsc
+FFLAGS = $(OPT_FLAGS) /fpp
 FFREE   = /free
 else # mac,linux
-CXX	?= icpc
-OPT_FLAGS	= -O2
-CXXFLAGS	= $(OPT_FLAGS) -std=c++11
-FFLAGS	= $(OPT_FLAGS) -fpp
-FFREE	= -free
-ifeq ($(SYSTEM),mac)
-MKLROOT = /opt/intel/compilers_and_libraries_2018.1.126/mac/mkl
+CXX = icpc
+OPT_FLAGS = -O2 -mkl=sequential
+CXXFLAGS = $(OPT_FLAGS) -std=c++11
+FFLAGS = $(OPT_FLAGS) -fpp
+FFREE = -free
 endif
-endif
-FC	?= ifort
+FC = ifort
 
 ifeq ($(SYSTEM),win)
 EXT_INCLUDES = -I"$(MKLROOT)"\include
 EXT_LIBS = \
     mkl_blas95_lp64.lib \
-    mkl_lapack95_lp64.lib \
+    mkl_lapack95_lp64.lib
+ifeq ($(STATIC),no)  # dynamic linking
+EXT_LIBS += \
+    mkl_intel_lp64_dll.lib \
+    mkl_sequential_dll.lib \
+    mkl_core_dll.lib
+else  # static linking
+EXT_LIBS += \
     mkl_intel_lp64.lib \
     mkl_sequential.lib \
     mkl_core.lib
+endif
 else ifeq ($(SYSTEM),linux)
 EXT_INCLUDES = -I${MKLROOT}/include/intel64/ilp64 -I${MKLROOT}/include
 EXT_LIBS = \
     ${MKLROOT}/lib/intel64/libmkl_blas95_lp64.a \
-    ${MKLROOT}/lib/intel64/libmkl_lapack95_lp64.a \
+    ${MKLROOT}/lib/intel64/libmkl_lapack95_lp64.a
+ifeq ($(STATIC),no)  # dynamic linking
+EXT_LIBS += \
+    -L${MKLROOT}/lib/intel64 \
+    -lmkl_intel_lp64 -lmkl_sequential -lmkl_core
+else  # static linking
+EXT_LIBS += \
     -Wl,--start-group \
         ${MKLROOT}/lib/intel64/libmkl_intel_lp64.a \
         ${MKLROOT}/lib/intel64/libmkl_sequential.a \
         ${MKLROOT}/lib/intel64/libmkl_core.a \
     -Wl,--end-group \
-    -lifport -lifcore -lpthread -lm -ldl
+    -lifport
+endif
+EXT_LIBS += -lifcore -lpthread -lm -ldl
 else ifeq ($(SYSTEM),mac)
-EXTRADIR = /opt/intel/compilers_and_libraries_2018.1.126/mac/compiler/lib
+MKLROOT ?= /opt/intel/compilers_and_libraries_2018.1.126/mac/mkl
+EXTRADIR = /opt/intel/compilers_and_libraries_2018.1.126/mac/compiler
 EXT_INCLUDES = -I${MKLROOT}/include/intel64/lp64 -I${MKLROOT}/include
 EXT_LIBS = \
     ${MKLROOT}/lib/libmkl_lapack95_ilp64.a \
-    ${MKLROOT}/lib/libmkl_blas95_ilp64.a \
+    ${MKLROOT}/lib/libmkl_blas95_ilp64.a
+ifeq ($(STATIC),no)  # dynamic linking
+EXT_LIBS += \
+    -L${MKLROOT}/lib \
+    -Wl,-rpath,${MKLROOT}/lib \
+    -lmkl_intel_lp64 -lmkl_sequential -lmkl_core
+else  # static linking
+EXT_LIBS += \
     ${MKLROOT}/lib/libmkl_intel_ilp64.a \
     ${MKLROOT}/lib/libmkl_sequential.a \
     ${MKLROOT}/lib/libmkl_core.a \
-    ${EXTRADIR}/libifcore.a
+    ${EXTRADIR}/lib/libifcore.a
 endif
-else ifeq ($(COMPILER),gcc)
-# GNU Compiler Collection
-CXX	?= g++
-FC	?= gfortran
-OPT_FLAGS	= -O2 -march=native
-CXXFLAGS	= $(OPT_FLAGS) -std=c++11
-FFLAGS	= $(OPT_FLAGS) -cpp
-FFREE	= -ffree-form
-EXT_LIBS	= -lpthread -llapack -lblas -lgfortran -lquadmath
+EXT_LIBS += -lpthread -lm -ldl
+endif # $(SYSTEM)
+else  # $(COMPILER)
+# Assume GNU Compiler Collection
+ifeq ($(COMPILER),gcc)
+CXX = g++
+FC = gfortran
 else
-$(error COMPILER not understood: $(COMPILER). Use one of intel or gcc.)
+CXX ?= g++
+FC ?= gfortran
 endif
+OPT_FLAGS = -O2
+CXXFLAGS = $(OPT_FLAGS) -std=c++11
+FFLAGS = $(OPT_FLAGS) -cpp
+FFREE = -ffree-form
+EXT_LIBS = -lpthread -llapack -lblas -lgfortran -lquadmath
+# else
+# $(error COMPILER not understood: $(COMPILER). Use one of intel or gcc.)
+endif  # $(COMPILER)
 
 # Assume linker is the C++ compiler
 LD = $(CXX)
 LDFLAGS += -pthread
-#LDFLAGS += -static
+ifneq ($(STATIC),no)
+LDFLAGS += $(STATIC)
+endif
 
 # r=insert with replacement; c=create archive; s=add index
 ARFLAGS := rcs
 
-LIBS_DIR :=	$(top_builddir)/libs
+LIBS_DIR := $(top_builddir)/libs
 
 PESTPP_INCLUDES := \
     -I $(LIBS_DIR)/Eigen \
@@ -164,22 +201,22 @@ PESTPP_LIBS := \
 
 # Generic pattern rules
 
-%$(OBJ_EXT):	%.cpp
+%$(OBJ_EXT): %.cpp
 	$(CXX) -c $(PESTPP_INCLUDES) $(CXXFLAGS) $(CPPFLAGS) -o $@ $<
 
-%$(OBJ_EXT):	%.f
+%$(OBJ_EXT): %.f
 	$(FC) -c $(FFLAGS) -o $@ $<
 
-%$(OBJ_EXT):	%.for
+%$(OBJ_EXT): %.for
 	$(FC) -c $(FFLAGS) -o $@ $<
 
-%$(OBJ_EXT):	%.f90
+%$(OBJ_EXT): %.f90
 	$(FC) -c $(FFLAGS) -o $@ $<
 
-%$(OBJ_EXT):	%.F
+%$(OBJ_EXT): %.F
 	$(FC) -c $(FFLAGS) $(CPPFLAGS) -o $@ $<
 
-%$(OBJ_EXT):	%.FOR
+%$(OBJ_EXT): %.FOR
 	$(FC) -c $(FFLAGS) $(CPPFLAGS) -o $@ $<
 
 .SUFFIXES: .c .h .cpp .hpp .f .for .F .FOR .mod $(OBJ_EXT) $(LIB_EXT)

--- a/src/programs/pestpp-pso/Makefile
+++ b/src/programs/pestpp-pso/Makefile
@@ -18,16 +18,16 @@ OBJECTS := \
     writesubs
 OBJECTS	:= $(addsuffix $(OBJ_EXT),$(OBJECTS))
 
+ifeq ($(COMPILER),intel)
+LD = $(FC)
+LDFLAGS += -cxxlib
+endif
+
 
 all: $(EXE)
 
 # Compile readsubs.f90 first, to get psodat.mod used by everything else
 $(filter-out readsubs$(OBJ_EXT),$(OBJECTS)): readsubs$(OBJ_EXT)
-
-ifeq ($(COMPILER),intel)
-LD = $(FC)
-LDFLAGS += -cxxlib
-endif
 
 $(EXE): $(OBJECTS)
 	$(LD) $(LDFLAGS) $^ $(PESTPP_LIBS) -o $@

--- a/src/tests/run_manager_fortran_test/Makefile
+++ b/src/tests/run_manager_fortran_test/Makefile
@@ -5,6 +5,11 @@ include $(top_builddir)/global.mak
 EXE := fortran_test$(EXE_EXT)
 OBJECTS := run_manager_fortran_test$(OBJ_EXT)
 
+ifeq ($(COMPILER),intel)
+LD = $(FC)
+LDFLAGS += -cxxlib
+endif
+
 
 all: $(EXE)
 


### PR DESCRIPTION
There are a few things happening here:
 * My previous change to bring in Travis CI (#21) broke the Intel build. The variables `CXX` and `FC` should not normally be used, as they are implied from `COMPILER`. The solution that I have right now is slightly hacky, but it a work-around since Travis CI does not natively support GCC5, which is the minimum requirement for PEST++. The build status [is back to green](https://travis-ci.org/mwtoews/pestpp/builds/351033261).
 * A `STATIC` Makefile variable is now available, where if it is `STATIC=no` (or from a command `STATIC= make`) then a dynamic linked executable is made. The default, if not specified, is to build statically linked executable, as was before.
 * Intel compilers explicitly use sequential MKL libraries. I don't think they were previously used, but they are now. They are linked according to static/dynamic suggestions from Intel's [Math Kernel Library Link Line Advisor](https://software.intel.com/en-us/articles/intel-mkl-link-line-advisor). I've adjusted the static/dynamic linking options too, which I've tested only for linux with gcc/intel, but not mac.
 * I've listed the non-Windows executables to `.gitignore` to avoid them creeping in.